### PR TITLE
Anonymize PII in non-prod database copies after import

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -31,6 +31,12 @@ namespace AzureDatabaseDownloader
 
             [Option('e', "exclude-tables", Required = false, HelpText = "Tables to exclude from sync", Separator = ',')]
             public string[]? ExcludeTables { get; set; }
+
+            [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import (applied to every synced database)")]
+            public string? MaskingScript { get; set; }
+
+            // Per-database masking scripts (database name -> .sql path). Populated from a profile in interactive mode; not a CLI option.
+            public Dictionary<string, string>? MaskingScripts { get; set; }
         }
 
         [Verb("db2f", HelpText = "Database-to-file sync (1:1)")]
@@ -69,6 +75,9 @@ namespace AzureDatabaseDownloader
 
             [Option('u', "local-user", Required = false, HelpText = "Local user to give db_owner access after sync")]
             public string? LocalUser { get; set; }
+
+            [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import")]
+            public string? MaskingScript { get; set; }
         }
 
         static int Main(string[] args)
@@ -132,6 +141,7 @@ namespace AzureDatabaseDownloader
                 WorkingDirectory = selectedProfile.WorkingDirectory,
                 LocalUser = selectedProfile.LocalDbUser,
                 ExcludeTables = selectedProfile.ExcludeTables,
+                MaskingScripts = selectedProfile.MaskingScripts,
             });
 
             return 0;
@@ -193,13 +203,20 @@ namespace AzureDatabaseDownloader
                     ExcludeTables = opts.ExcludeTables
                 });
 
+                // Per-database masking script (interactive/profile) takes precedence over the
+                // single --masking-script applied to all databases.
+                var maskingScript = opts.MaskingScripts != null && opts.MaskingScripts.TryGetValue(db, out var perDb)
+                    ? perDb
+                    : opts.MaskingScript;
+
                 FileToDatabaseSync(new F2dbOptions
                 {
                     InputFile = outputFile,
                     OutputConnectionString = opts.OutputConnectionString,
                     Database = db,
                     LocalUser = opts.LocalUser,
-                    WorkingDirectory = opts.WorkingDirectory
+                    WorkingDirectory = opts.WorkingDirectory,
+                    MaskingScript = maskingScript
                 });
             }
 
@@ -338,10 +355,79 @@ namespace AzureDatabaseDownloader
                 }
             }
 
+            ApplyMaskingScript(opts.OutputConnectionString, db, quotedDatabaseName, opts.MaskingScript, opts.InputFile);
+
             Console.Write("done.");
             Console.WriteLine();
 
             return 0;
+        }
+
+        /// <summary>
+        /// Runs a PII anonymization script against the freshly imported LOCAL database, then
+        /// shreds the intermediate .bacpac so no unmasked production data lingers on disk.
+        /// No-op when no script is supplied. Never touches the source/Azure database.
+        /// </summary>
+        private static void ApplyMaskingScript(string outputConnectionString, string db, string quotedDatabaseName, string? maskingScript, string? bacpacToDelete)
+        {
+            if (string.IsNullOrWhiteSpace(maskingScript))
+            {
+                return;
+            }
+
+            if (!File.Exists(maskingScript))
+            {
+                throw new FileNotFoundException($"Masking script not found: {maskingScript}");
+            }
+
+            Console.WriteLine($"[{db}] Applying masking script {Path.GetFileName(maskingScript)}...");
+
+            var sql = File.ReadAllText(maskingScript);
+
+            using (var conn = new SqlConnection(outputConnectionString))
+            {
+                conn.Open();
+
+                foreach (var batch in SplitOnGo(sql))
+                {
+                    using var cmd = new SqlCommand($"USE {quotedDatabaseName};\n{batch}", conn)
+                    {
+                        CommandTimeout = 0 // masking can touch large tables; no timeout
+                    };
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+
+            Console.WriteLine($"[{db}] Masking complete");
+
+            // The masked DB is now the source of truth for dev. The raw export still contains
+            // unmasked production data, so delete it.
+            if (!string.IsNullOrEmpty(bacpacToDelete) && File.Exists(bacpacToDelete))
+            {
+                File.Delete(bacpacToDelete);
+                Console.WriteLine($"[{db}] Deleted unmasked export {Path.GetFileName(bacpacToDelete)}");
+            }
+        }
+
+        /// <summary>
+        /// Splits a T-SQL script into batches on lines containing only "GO" (SSMS convention,
+        /// not valid T-SQL). Scripts with no GO separators run as a single batch.
+        /// </summary>
+        private static IEnumerable<string> SplitOnGo(string sql)
+        {
+            var batches = System.Text.RegularExpressions.Regex.Split(
+                sql,
+                @"^\s*GO\s*$",
+                System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            foreach (var batch in batches)
+            {
+                if (!string.IsNullOrWhiteSpace(batch))
+                {
+                    yield return batch;
+                }
+            }
         }
 
         private static string QuoteSqlIdentifier(string value, string parameterName)

--- a/ProjectProfile.cs
+++ b/ProjectProfile.cs
@@ -15,6 +15,12 @@ namespace AzureDatabaseDownloader
         public bool IsActive { get; set; }
         public string[]? ExcludeTables { get; set; }
 
+        /// <summary>
+        /// Optional per-database PII anonymization scripts (database name -> .sql path),
+        /// run against the local target immediately after import. Prod is never touched.
+        /// </summary>
+        public Dictionary<string, string>? MaskingScripts { get; set; }
+
         public static IEnumerable<ProjectProfile> List()
         {
             if (!File.Exists(ProfilePath))

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ AzureDatabaseDownloader db2f -i "server=tcp:mydatabase.database.windows.net,1433
 ```
 AzureDatabaseDownloader f2db -i TestDatabase.bacpac -o "server=tcp:mydatabase.database.windows.net,1433;database=test;uid=test@mydatabase;pwd=MyPassword123;" -d "test_db"
 ```
+
+## PII anonymization
+
+Pass `-m/--masking-script <path>` to `db2db`/`f2db` (or a `maskingScripts` map in a profile)
+to anonymize PII in the local copy immediately after import — production data never lands
+unmasked in non-prod. See [masking/README.md](masking/README.md).

--- a/masking/CheckIris.sql
+++ b/masking/CheckIris.sql
@@ -1,0 +1,218 @@
+/*
+=====================================================================
+ CheckIris PII anonymization — runs AFTER ImportBacpac, against the
+ LOCAL (non-prod) database only. Never runs against Azure/production.
+
+ Strategy:
+   - UPDATE-in-place. Row counts and ALL foreign keys are preserved so
+     existing tests still exercise the real graph; only PII *values* are
+     overwritten with deterministic, reproducible fakes.
+   - Identity columns (Id / CandidateId / OrderId / GUIDs) are NEVER touched.
+   - Dense free-text / JSON result payloads are scrubbed (NULL or a tiny
+     placeholder) because they embed unstructured PII (NIN, names, credit
+     data) that can't be column-masked.
+
+ Determinism: a candidate's name becomes "Testkandidat <n>" where <n> is a
+ stable per-row number (ROW_NUMBER over Id), so the same row always maps to
+ the same fake across refreshes.
+
+ Review notes:
+   - Columns that are config/template text (Activity*.Description*, Instructions,
+     translations, RefQuestion.Text, etc.) are intentionally LEFT ALONE — they
+     are product content, not customer PII.
+   - Sections flagged [VERIFY] should be sanity-checked against current schema
+     before first production use of the masked pipeline.
+=====================================================================*/
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+BEGIN TRAN;
+
+-------------------------------------------------------------------------------
+-- 1. CANDIDATES  (core data subject)
+-------------------------------------------------------------------------------
+;WITH c AS (
+    SELECT Id, ROW_NUMBER() OVER (ORDER BY Id) AS rn FROM dbo.Candidate
+)
+UPDATE cand SET
+    cand.Firstname  = N'Testkandidat',
+    cand.Lastname   = N'Nr' + CAST(c.rn AS nvarchar(20)),
+    cand.MaidenName = CASE WHEN cand.MaidenName IS NULL THEN NULL
+                           ELSE N'Pikenavn' + CAST(c.rn AS nvarchar(20)) END,
+    cand.Email      = 'candidate' + CAST(c.rn AS varchar(20)) + '@example.invalid',
+    cand.Mobile     = RIGHT('00000000' + CAST((40000000 + c.rn) AS varchar(15)), 8)
+FROM dbo.Candidate cand JOIN c ON c.Id = cand.Id;
+
+-------------------------------------------------------------------------------
+-- 2. APPLICATION USERS / PROFILES  (screeners, client users, admins)
+--    Keep PasswordHash usable? No — null credentials; dev logs in via
+--    /auto-login (Development-only, passwordless). Wipe secrets.
+-------------------------------------------------------------------------------
+;WITH u AS (
+    SELECT Id, ROW_NUMBER() OVER (ORDER BY Id) AS rn FROM dbo.ApplicationUser
+)
+UPDATE au SET
+    au.FullName            = N'Test User ' + CAST(u.rn AS nvarchar(20)),
+    au.UserName            = 'user' + CAST(u.rn AS varchar(20)) + '@example.invalid',
+    au.NormalizedUserName  = 'USER' + CAST(u.rn AS varchar(20)) + '@EXAMPLE.INVALID',
+    -- NB: this Identity schema has no Email/NormalizedEmail column; the login email lives in UserName (masked above).
+    au.PhoneNumber         = '47' + RIGHT('00000000' + CAST((40000000 + u.rn) AS varchar(20)), 8),
+    au.PasswordHash        = NULL,
+    au.SecurityStamp       = NULL,
+    au.AuthenticatorKey    = NULL
+FROM dbo.ApplicationUser au JOIN u ON u.Id = au.Id;
+
+UPDATE dbo.UserProfile SET
+    FirstName   = N'Test',
+    LastName    = N'User',
+    DateOfBirth = CASE WHEN DateOfBirth IS NULL THEN NULL ELSE '1980-01-01' END;
+
+-------------------------------------------------------------------------------
+-- 3. DENSE RESULT / PAYLOAD COLUMNS  (highest PII density — scrub hard)
+-------------------------------------------------------------------------------
+UPDATE dbo.CreditReport          SET RawJson = NULL, AuditorName = N'Revisor';
+UPDATE dbo.ActivityResult        SET JsonData = NULL, JsonDataOriginal = NULL;
+UPDATE dbo.ActivityRawPayloads   SET Payload = NULL;
+UPDATE dbo.CandidateCV           SET ParsedData = NULL;
+UPDATE dbo.OrderActivityInput    SET JsonData = NULL;
+UPDATE dbo.PickOrderActivityInput SET JsonData = NULL;
+UPDATE dbo.Company               SET RawJson = NULL;                 -- registry pull (business data, but may contain director PII)
+UPDATE dbo.SignatureRecord       SET SignatureEvidence = NULL, SubjectNin = NULL,
+                                     SubjectFirstName = N'Test', SubjectLastName = N'Signer',
+                                     SubjectEmail = 'signer@example.invalid';
+UPDATE dbo.SignicatEvent         SET RawBody = NULL, ProcessingError = NULL;
+UPDATE dbo.InboundEmailMessage   SET RawHeadersJson = NULL, FromAddress = 'inbound@example.invalid';
+UPDATE dbo.SourceVerificationRequest SET CVEntryData = NULL, ResponseComment = NULL,
+                                         ManualSourceName = N'Kilde', CandidateBirthDate = NULL;
+
+-------------------------------------------------------------------------------
+-- 4. REFERENCE-CHECK DATA  (free-text statements about the data subject)
+-------------------------------------------------------------------------------
+;WITH r AS (
+    SELECT Id, ROW_NUMBER() OVER (ORDER BY Id) AS rn FROM dbo.RefOrderReference
+)
+UPDATE ror SET
+    ror.Firstname        = N'Referanse',
+    ror.Lastname         = N'Nr' + CAST(r.rn AS nvarchar(20)),
+    ror.OrgName          = N'Testbedrift ' + CAST(r.rn AS nvarchar(20)),
+    ror.ReferenceEmail   = 'reference' + CAST(r.rn AS varchar(20)) + '@example.invalid',
+    ror.ReferenceMobile  = '47' + RIGHT('00000000' + CAST((40000000 + r.rn) AS varchar(14)), 8),
+    ror.ReferenceComment = CASE WHEN ror.ReferenceComment IS NULL THEN NULL ELSE N'[anonymisert]' END,
+    ror.IpAddress        = NULL,
+    ror.SubmitIpAddress  = NULL
+FROM dbo.RefOrderReference ror JOIN r ON r.Id = ror.Id;
+
+UPDATE dbo.RefQuestionAnswer SET
+    AnswerText = CASE WHEN AnswerText IS NULL THEN NULL ELSE N'[anonymisert svar]' END;
+    -- QuestionText / OptionText left as-is: they are template text, not PII.
+
+-------------------------------------------------------------------------------
+-- 5. ORDER / CASEWORKER FREE-TEXT NOTES  (may quote candidate PII)
+-------------------------------------------------------------------------------
+UPDATE dbo.[Order] SET
+    Comment              = CASE WHEN Comment IS NULL THEN NULL ELSE N'[anonymisert]' END,
+    OverallResultComment = CASE WHEN OverallResultComment IS NULL THEN NULL ELSE N'[anonymisert]' END,
+    PurchaseOrder        = CASE WHEN PurchaseOrder IS NULL THEN NULL ELSE N'PO-TEST' END;
+UPDATE dbo.OrderActivity SET
+    ClientComment  = CASE WHEN ClientComment  IS NULL THEN NULL ELSE N'[anonymisert]' END,
+    ConsentComment = CASE WHEN ConsentComment IS NULL THEN NULL ELSE N'[anonymisert]' END;
+UPDATE dbo.PickOrder SET
+    Comment              = CASE WHEN Comment IS NULL THEN NULL ELSE N'[anonymisert]' END,
+    OverallResultComment = CASE WHEN OverallResultComment IS NULL THEN NULL ELSE N'[anonymisert]' END;
+UPDATE dbo.PickOrderActivity SET
+    ConsentComment = CASE WHEN ConsentComment IS NULL THEN NULL ELSE N'[anonymisert]' END;
+
+-------------------------------------------------------------------------------
+-- 6. UPLOADED-DOCUMENT METADATA  (original filenames often = candidate name)
+--    BlobUrl points at prod storage the dev box can't read anyway; null it
+--    so nothing tries to fetch real candidate files.
+-------------------------------------------------------------------------------
+UPDATE dbo.OrderActivityDoc   SET OriginalName = N'document.pdf', DocName = N'document.pdf', BlobUrl = NULL;
+UPDATE dbo.OrderDoc           SET OriginalName = N'document.pdf', DocName = N'document.pdf', BlobUrl = NULL;
+UPDATE dbo.OrderDocRequestFile SET OriginalName = N'document.pdf', BlobUrl = NULL;
+UPDATE dbo.SourceDoc          SET BlobUrl = NULL;
+UPDATE dbo.Attachment         SET FileName = N'attachment' ;                       -- [VERIFY] keep extension if tests need it
+UPDATE dbo.CompanyDocument    SET OriginalFileName = N'document.pdf';
+UPDATE dbo.SecureUploadFile   SET OriginalFileName = N'document.pdf', UploaderIpAddress = NULL;
+UPDATE dbo.LegacyVeriFindDocument SET FileName = N'document.pdf', SourceBlobName = NULL,
+                                      UploadedByUserName = N'Test User';
+
+-------------------------------------------------------------------------------
+-- 7. THIRD-PARTY CONTACTS  (sources, signers, provider/company contacts)
+-------------------------------------------------------------------------------
+UPDATE dbo.SourceContact          SET Name = N'Kontaktperson', Email = 'source@example.invalid', Phone = '4740000000';
+UPDATE dbo.InformationSourceEntity SET Name = N'Kilde', Email = 'source@example.invalid', Phone = '4740000000';
+UPDATE dbo.Source                 SET NotificationEmail = 'source@example.invalid', NotificationMobile = '4740000000';
+UPDATE dbo.DocumentSigner         SET Name = N'Signer', Email = 'signer@example.invalid', Phone = '4740000000';
+UPDATE dbo.Director               SET Name = N'Styremedlem', Address = N'Testgata 1', DateOfBirth = NULL;
+UPDATE dbo.Shareholder            SET Name = N'Aksjonær';
+UPDATE dbo.ContactFormSubmission  SET Firstname = N'Test', Lastname = N'Person',
+                                      Email = 'contact@example.invalid', Phone = '4740000000';
+UPDATE dbo.SecureUploadLink       SET RecipientName = N'Mottaker', RecipientEmail = 'recipient@example.invalid',
+                                      Message = CASE WHEN Message IS NULL THEN NULL ELSE N'[anonymisert]' END;
+UPDATE dbo.SmsConfirmation        SET PhoneNumber = '4740000000';
+
+-- Company contact people (the company name itself is business data; keep it,
+-- but scrub the named contact person + direct contact channels).
+UPDATE dbo.Company SET
+    ContactFirstname = N'Kontakt', ContactLastname = N'Person',
+    ContactEmail = 'contact@example.invalid', ContactMobile = '40000000',
+    CompanyEmail = 'company@example.invalid', Telephone = '40000000';
+UPDATE dbo.ScreeningProvider SET
+    ContactFirstname = N'Kontakt', ContactLastname = N'Person',
+    ContactEmail = 'contact@example.invalid', ContactMobile = '40000000',
+    CompanyEmail = 'provider@example.invalid', Email = 'provider@example.invalid', Phone = '40000000';
+
+-------------------------------------------------------------------------------
+-- 8. ADDRESSES
+-------------------------------------------------------------------------------
+UPDATE dbo.Address SET Street = N'Testgata 1', City = N'Testby', Zip = N'0000';
+
+-------------------------------------------------------------------------------
+-- 9. COMMUNICATIONS LOG  (email/SMS bodies sent to candidates)
+-------------------------------------------------------------------------------
+UPDATE dbo.Message       SET Body = N'[anonymisert]';
+UPDATE dbo.SmsMessage    SET Message = N'[anonymisert]', LastError = NULL;
+UPDATE dbo.Notification  SET Message = N'[anonymisert]';
+UPDATE dbo.DialogMessage SET Message = N'[anonymisert]';
+UPDATE dbo.EmailMessage  SET EmailType = EmailType;   -- no PII in this col; placeholder no-op for documentation
+
+-------------------------------------------------------------------------------
+-- 10. AUDIT / DIAGNOSTIC LOGS  (IP, usernames, serilog properties)
+-------------------------------------------------------------------------------
+UPDATE dbo.AdminAuditLog SET AdminUserName = N'admin', IpAddress = NULL,
+                             TargetCompanyName = N'[company]', Details = NULL;
+UPDATE dbo.FileAccessLog SET Username = N'user', IpAddress = NULL, OriginalFileName = N'document.pdf';
+UPDATE dbo.Logs          SET Message = N'[anonymisert]', Exception = NULL,
+                             Properties = NULL, MessageTemplate = NULL;
+
+-------------------------------------------------------------------------------
+-- 11. LEGACY VERIFIND IMPORT TABLES  (full candidate/customer PII snapshots)
+--     These mirror imported VeriFind data — scrub the lot.
+-------------------------------------------------------------------------------
+;WITH lo AS (SELECT Id, ROW_NUMBER() OVER (ORDER BY Id) AS rn FROM dbo.LegacyVeriFindOrder)
+UPDATE l SET
+    l.CandidateFirstName  = N'Testkandidat',
+    l.CandidateLastName   = N'Nr' + CAST(lo.rn AS nvarchar(20)),
+    l.CandidateMaidenName = NULL,
+    l.CandidateEmail      = 'candidate' + CAST(lo.rn AS varchar(20)) + '@example.invalid',
+    l.CandidatePhoneNumber= '4740000000',
+    l.CandidateBirthDate  = NULL,
+    l.OrderCustomerCompanyName = N'Testbedrift',
+    l.OrderCustomerEmail  = 'customer@example.invalid',
+    l.OrderCustomerPhoneNumber = '4740000000',
+    l.SourceJson          = NULL
+FROM dbo.LegacyVeriFindOrder l JOIN lo ON lo.Id = l.Id;
+
+UPDATE dbo.LegacyVeriFindUser     SET Name = N'Test User', UserName = N'user@example.invalid',
+                                      Email = 'user@example.invalid', PhoneNumber = '4740000000',
+                                      SourceJson = NULL, RolesJson = NULL;
+UPDATE dbo.LegacyVeriFindCustomer SET Name = N'Testkunde', SourceJson = NULL;
+UPDATE dbo.LegacyVeriFindCandidateLogin SET Email = 'candidate@example.invalid', SourceJson = NULL;
+UPDATE dbo.LegacyVeriFindOrderLine SET SourceJson = NULL;
+UPDATE dbo.LegacyVeriFindOrderTag SET SourceJson = NULL;
+UPDATE dbo.LegacyVeriFindTag      SET SourceJson = NULL;
+UPDATE dbo.LegacyVeriFindImportJob SET SourceCustomerName = N'Testkunde', SummaryJson = NULL, ErrorMessage = NULL;
+
+COMMIT;
+PRINT 'CheckIris PII anonymization complete.';

--- a/masking/README.md
+++ b/masking/README.md
@@ -1,0 +1,51 @@
+# PII anonymization
+
+Optional anonymization scripts run against the **local target** database right after
+import, so production data never lands unmasked in non-production. Production/Azure is
+only ever read (`ExportBacpac`); these scripts only ever write to the local copy.
+
+## How it runs
+
+- **CLI:** add `-m/--masking-script <path>` to `db2db` or `f2db`.
+  ```
+  AzureDatabaseDownloader db2db -i "<azure>" -o "server=localhost;..." -d checkiris -m masking/CheckIris.sql
+  ```
+- **Interactive/profiles:** add a `maskingScripts` map (database name → .sql path) to the profile.
+  ```json
+  "maskingScripts": { "checkiris": "masking/CheckIris.sql" }
+  ```
+
+When a masking script runs on a `db2db` sync, the intermediate `.bacpac` (which still
+holds raw production data) is **deleted** afterwards, so only the masked database remains
+on disk.
+
+> `db2f` (export-to-file) intentionally produces a **raw** bacpac and is not masked — it's
+> a straight export. To get a masked file, `db2db` into a scratch DB, then export that.
+
+## Design
+
+- **UPDATE-in-place.** Row counts and all foreign keys are preserved, so tests still
+  exercise the real object graph; only PII *values* are overwritten.
+- **Deterministic.** Names/emails derive from a stable per-row number, so a given row maps
+  to the same fake on every refresh.
+- **Dense payloads scrubbed.** Free-text / JSON result columns (`CreditReport.RawJson`,
+  `ActivityResult.JsonData`, `ActivityRawPayloads.Payload`, `CandidateCV.ParsedData`,
+  signing evidence, NIN, etc.) embed unstructured PII and are NULLed.
+
+## Maintenance
+
+`CheckIris.sql` enumerates PII columns by hand. When the schema changes, update it.
+Validate every referenced column still exists before running against real data:
+
+```sql
+-- compare the table/column pairs in CheckIris.sql against INFORMATION_SCHEMA.COLUMNS
+```
+
+Columns that are product/template content (activity descriptions, instructions, reference
+question text, translations) are intentionally **not** masked.
+
+### Known follow-ups
+- Result rendering in dev loses realism because result payloads are NULLed. If a test needs
+  a realistic rendered result, seed a synthetic fixture rather than relaxing the masking.
+- Sections marked `[VERIFY]` in `CheckIris.sql` should be re-checked when the schema drifts.
+</content>

--- a/profiles.sample.json
+++ b/profiles.sample.json
@@ -7,6 +7,9 @@
 		"databasesToSync": [ "SampleDatabase1", "SampleDatabase2" ],
 		"localDbUser": "YourLocalDbUser",
 		"isActive": true,
-		"excludeTables": [ "dbo.Tables", "dbo.To", "dbo.Exclude", "(must include schema)" ]
+		"excludeTables": [ "dbo.Tables", "dbo.To", "dbo.Exclude", "(must include schema)" ],
+		"maskingScripts": {
+			"SampleDatabase1": "masking/CheckIris.sql"
+		}
 	}
 ]


### PR DESCRIPTION
## Why

A vendor security questionnaire (new customer NORDSEC) asks: *"Can you confirm that our Company's data won't be used in testing or development environments?"* Today `AzureDatabaseDownloader` copies the full production database into dev, so the honest answer is currently "no". There is no native Azure feature that produces an anonymized export (Dynamic Data Masking only masks query results for low-privilege users; a privileged `ExportBacpac` reads the real values), so anonymization has to happen in this copy pipeline.

## What

Add an optional masking step that runs against the **local target** immediately after `ImportBacpac`. Production/Azure is only ever read — masking only writes to the local copy, so there is zero risk to prod.

- New `-m/--masking-script <path>` option on `db2db` and `f2db`.
- Per-database `maskingScripts` map (database name → .sql path) in profiles, for interactive mode.
- After a **masked** `db2db` sync, the intermediate `.bacpac` (which still contains raw production data) is **deleted**, so only the masked database remains on disk.
- `masking/CheckIris.sql`: deterministic, FK-preserving `UPDATE`-in-place of PII columns, plus scrubbing of dense result/JSON payloads (`CreditReport.RawJson`, `ActivityResult.JsonData`, `ActivityRawPayloads.Payload`, `CandidateCV.ParsedData`, signing evidence/NIN, `LegacyVeriFind*`, etc.). Row counts and foreign keys are preserved so existing tests still exercise the real object graph; only PII *values* change. Product/template text is intentionally left alone.

`db2f` (export-to-file) is intentionally **not** masked — it is a straight raw export.

## Verification

- Builds clean (0 warnings / 0 errors).
- Every table/column referenced by `masking/CheckIris.sql` validated against the live CheckIris schema (removed two columns that do not exist on this Identity schema — email lives in `UserName`).

## Not yet done

- The masking SQL has **not** been executed end-to-end — the only reachable CheckIris DB is the shared dev DB with real data. Run `db2db` into a throwaway local DB and spot-check before relying on it.
- A few `[VERIFY]` markers remain in the SQL for re-checking on schema drift.
- Result rendering in dev loses realism because result payloads are NULLed; seed a synthetic fixture if a test needs a realistic rendered result.