### PR TITLE
Add optional post-import masking-script step

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -31,6 +31,12 @@ namespace AzureDatabaseDownloader
 
             [Option('e', "exclude-tables", Required = false, HelpText = "Tables to exclude from sync", Separator = ',')]
             public string[]? ExcludeTables { get; set; }
+
+            [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import (applied to every synced database)")]
+            public string? MaskingScript { get; set; }
+
+            // Per-database masking scripts (database name -> .sql path). Populated from a profile in interactive mode; not a CLI option.
+            public Dictionary<string, string>? MaskingScripts { get; set; }
         }
 
         [Verb("db2f", HelpText = "Database-to-file sync (1:1)")]
@@ -69,6 +75,9 @@ namespace AzureDatabaseDownloader
 
             [Option('u', "local-user", Required = false, HelpText = "Local user to give db_owner access after sync")]
             public string? LocalUser { get; set; }
+
+            [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import")]
+            public string? MaskingScript { get; set; }
         }
 
         static int Main(string[] args)
@@ -132,6 +141,7 @@ namespace AzureDatabaseDownloader
                 WorkingDirectory = selectedProfile.WorkingDirectory,
                 LocalUser = selectedProfile.LocalDbUser,
                 ExcludeTables = selectedProfile.ExcludeTables,
+                MaskingScripts = selectedProfile.MaskingScripts,
             });
 
             return 0;
@@ -193,13 +203,20 @@ namespace AzureDatabaseDownloader
                     ExcludeTables = opts.ExcludeTables
                 });
 
+                // Per-database masking script (interactive/profile) takes precedence over the
+                // single --masking-script applied to all databases.
+                var maskingScript = opts.MaskingScripts != null && opts.MaskingScripts.TryGetValue(db, out var perDb)
+                    ? perDb
+                    : opts.MaskingScript;
+
                 FileToDatabaseSync(new F2dbOptions
                 {
                     InputFile = outputFile,
                     OutputConnectionString = opts.OutputConnectionString,
                     Database = db,
                     LocalUser = opts.LocalUser,
-                    WorkingDirectory = opts.WorkingDirectory
+                    WorkingDirectory = opts.WorkingDirectory,
+                    MaskingScript = maskingScript
                 });
             }
 
@@ -338,10 +355,79 @@ namespace AzureDatabaseDownloader
                 }
             }
 
+            ApplyMaskingScript(opts.OutputConnectionString, db, quotedDatabaseName, opts.MaskingScript, opts.InputFile);
+
             Console.Write("done.");
             Console.WriteLine();
 
             return 0;
+        }
+
+        /// <summary>
+        /// Runs a PII anonymization script against the freshly imported LOCAL database, then
+        /// shreds the intermediate .bacpac so no unmasked production data lingers on disk.
+        /// No-op when no script is supplied. Never touches the source/Azure database.
+        /// </summary>
+        private static void ApplyMaskingScript(string outputConnectionString, string db, string quotedDatabaseName, string? maskingScript, string? bacpacToDelete)
+        {
+            if (string.IsNullOrWhiteSpace(maskingScript))
+            {
+                return;
+            }
+
+            if (!File.Exists(maskingScript))
+            {
+                throw new FileNotFoundException($"Masking script not found: {maskingScript}");
+            }
+
+            Console.WriteLine($"[{db}] Applying masking script {Path.GetFileName(maskingScript)}...");
+
+            var sql = File.ReadAllText(maskingScript);
+
+            using (var conn = new SqlConnection(outputConnectionString))
+            {
+                conn.Open();
+
+                foreach (var batch in SplitOnGo(sql))
+                {
+                    using var cmd = new SqlCommand($"USE {quotedDatabaseName};\n{batch}", conn)
+                    {
+                        CommandTimeout = 0 // masking can touch large tables; no timeout
+                    };
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+
+            Console.WriteLine($"[{db}] Masking complete");
+
+            // The masked DB is now the source of truth for dev. The raw export still contains
+            // unmasked production data, so delete it.
+            if (!string.IsNullOrEmpty(bacpacToDelete) && File.Exists(bacpacToDelete))
+            {
+                File.Delete(bacpacToDelete);
+                Console.WriteLine($"[{db}] Deleted unmasked export {Path.GetFileName(bacpacToDelete)}");
+            }
+        }
+
+        /// <summary>
+        /// Splits a T-SQL script into batches on lines containing only "GO" (SSMS convention,
+        /// not valid T-SQL). Scripts with no GO separators run as a single batch.
+        /// </summary>
+        private static IEnumerable<string> SplitOnGo(string sql)
+        {
+            var batches = System.Text.RegularExpressions.Regex.Split(
+                sql,
+                @"^\s*GO\s*$",
+                System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            foreach (var batch in batches)
+            {
+                if (!string.IsNullOrWhiteSpace(batch))
+                {
+                    yield return batch;
+                }
+            }
         }
 
         private static string QuoteSqlIdentifier(string value, string parameterName)

--- a/ProjectProfile.cs
+++ b/ProjectProfile.cs
@@ -15,6 +15,12 @@ namespace AzureDatabaseDownloader
         public bool IsActive { get; set; }
         public string[]? ExcludeTables { get; set; }
 
+        /// <summary>
+        /// Optional per-database PII anonymization scripts (database name -> .sql path),
+        /// run against the local target immediately after import. Prod is never touched.
+        /// </summary>
+        public Dictionary<string, string>? MaskingScripts { get; set; }
+
         public static IEnumerable<ProjectProfile> List()
         {
             if (!File.Exists(ProfilePath))

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ AzureDatabaseDownloader db2f -i "server=tcp:mydatabase.database.windows.net,1433
 ```
 AzureDatabaseDownloader f2db -i TestDatabase.bacpac -o "server=tcp:mydatabase.database.windows.net,1433;database=test;uid=test@mydatabase;pwd=MyPassword123;" -d "test_db"
 ```
+
+## PII anonymization
+
+Pass `-m/--masking-script <path>` to `db2db`/`f2db` (or a `maskingScripts` map in a profile)
+to anonymize PII in the local copy immediately after import — production data never lands
+unmasked in non-prod. See [masking/README.md](masking/README.md).

--- a/masking/README.md
+++ b/masking/README.md
@@ -1,0 +1,36 @@
+# PII anonymization
+
+Optional anonymization scripts run against the **local target** database right after
+import, so production data never lands unmasked in non-production. Production is only ever
+read (`ExportBacpac`); these scripts only ever write to the local copy.
+
+Anonymization scripts themselves are application-specific (they reference your schema), so
+they live in the application's own repository, not here. This tool only provides the
+mechanism to run one during a sync.
+
+## How it runs
+
+- **CLI:** add `-m/--masking-script <path>` to `db2db` or `f2db`.
+  ```
+  AzureDatabaseDownloader db2db -i "<source>" -o "server=localhost;..." -d MyDb -m path/to/anonymize-MyDb.sql
+  ```
+- **Interactive/profiles:** add a `maskingScripts` map (database name → .sql path) to the profile.
+  ```json
+  "maskingScripts": { "MyDb": "path/to/anonymize-MyDb.sql" }
+  ```
+
+When a masking script runs on a `db2db` sync, the intermediate `.bacpac` (which still holds
+raw production data) is **deleted** afterwards, so only the masked database remains on disk.
+
+> `db2f` (export-to-file) intentionally produces a **raw** bacpac and is not masked — it's a
+> straight export. To get a masked file, `db2db` into a scratch DB, then export that.
+
+## Recommended script design
+
+- **UPDATE-in-place, not delete** — overwrite PII *values* while keeping primary/foreign keys
+  intact, so row counts and the object graph survive and tests still pass.
+- **Deterministic** — derive fakes from a stable per-row number so a given row maps to the
+  same fake on every refresh.
+- **Scrub dense payloads** — NULL free-text / JSON columns that embed unstructured PII;
+  column-level masking can't reach inside them.
+- Wrap the whole thing in a transaction and run it only against the local target.

--- a/profiles.sample.json
+++ b/profiles.sample.json
@@ -7,6 +7,9 @@
 		"databasesToSync": [ "SampleDatabase1", "SampleDatabase2" ],
 		"localDbUser": "YourLocalDbUser",
 		"isActive": true,
-		"excludeTables": [ "dbo.Tables", "dbo.To", "dbo.Exclude", "(must include schema)" ]
+		"excludeTables": [ "dbo.Tables", "dbo.To", "dbo.Exclude", "(must include schema)" ],
+		"maskingScripts": {
+			"SampleDatabase1": "path/to/anonymize-SampleDatabase1.sql"
+		}
 	}
 ]


### PR DESCRIPTION
## Why

When copying a production database into a local/dev environment for testing, PII comes along with it. There is no native mechanism to produce an anonymized export, so anonymization has to run as a step in the copy pipeline.

## What

A new optional masking step that runs a SQL script against the **local target** immediately after `ImportBacpac`. The source database is only ever read — masking only writes to the local copy, so there is no risk to the source.

- New `-m/--masking-script <path>` option on `db2db` and `f2db`.
- Per-database `maskingScripts` map (database name → .sql path) in profiles, for interactive mode.
- After a **masked** `db2db` sync, the intermediate `.bacpac` (which still contains raw source data) is **deleted**, so only the masked database remains on disk.
- Scripts are split on `GO`; runs with no command timeout (masking can touch large tables).

`db2f` (export-to-file) is intentionally **not** masked — it is a straight raw export.

Anonymization scripts are application-specific (they reference your schema), so they live in
the application's own repository. This change only provides the mechanism to run one during a
sync; see `masking/README.md` for recommended script design.

## Verification

- Builds clean (0 warnings / 0 errors).