### PR TITLE
Add optional post-import stored-procedure step

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -35,6 +35,11 @@ namespace AzureDatabaseDownloader
             [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import (applied to every synced database)")]
             public string? MaskingScript { get; set; }
 
+            // Project-level stored procedures to EXEC after import, applied to every synced
+            // database. Set from the CLI option or, in interactive mode, from the profile.
+            [Option('p', "post-import-procedures", Required = false, HelpText = "Stored procedures to EXEC against the local target after import (applied to every synced database)", Separator = ';')]
+            public string[]? PostImportProcedures { get; set; }
+
             // Per-database masking scripts (database name -> .sql path). Populated from a profile in interactive mode; not a CLI option.
             public Dictionary<string, string>? MaskingScripts { get; set; }
         }
@@ -78,6 +83,9 @@ namespace AzureDatabaseDownloader
 
             [Option('m', "masking-script", Required = false, HelpText = "PII anonymization .sql run against the local target after import")]
             public string? MaskingScript { get; set; }
+
+            [Option('p', "post-import-procedures", Required = false, HelpText = "Stored procedures to EXEC against the local target after import", Separator = ';')]
+            public string[]? PostImportProcedures { get; set; }
         }
 
         static int Main(string[] args)
@@ -142,6 +150,7 @@ namespace AzureDatabaseDownloader
                 LocalUser = selectedProfile.LocalDbUser,
                 ExcludeTables = selectedProfile.ExcludeTables,
                 MaskingScripts = selectedProfile.MaskingScripts,
+                PostImportProcedures = selectedProfile.PostImportProcedures,
             });
 
             return 0;
@@ -216,7 +225,9 @@ namespace AzureDatabaseDownloader
                     Database = db,
                     LocalUser = opts.LocalUser,
                     WorkingDirectory = opts.WorkingDirectory,
-                    MaskingScript = maskingScript
+                    MaskingScript = maskingScript,
+                    // Project-level procedures apply to every synced database.
+                    PostImportProcedures = opts.PostImportProcedures
                 });
             }
 
@@ -355,7 +366,16 @@ namespace AzureDatabaseDownloader
                 }
             }
 
-            ApplyMaskingScript(opts.OutputConnectionString, db, quotedDatabaseName, opts.MaskingScript, opts.InputFile);
+            var masked = ApplyMaskingScript(opts.OutputConnectionString, db, quotedDatabaseName, opts.MaskingScript);
+            var ranProcedures = ApplyPostImportProcedures(opts.OutputConnectionString, db, quotedDatabaseName, opts.PostImportProcedures);
+
+            // If any sanitizing step ran, shred the raw export so unmasked/unpurged source
+            // data does not linger on disk.
+            if ((masked || ranProcedures) && !string.IsNullOrEmpty(opts.InputFile) && File.Exists(opts.InputFile))
+            {
+                File.Delete(opts.InputFile);
+                Console.WriteLine($"[{db}] Deleted raw export {Path.GetFileName(opts.InputFile)}");
+            }
 
             Console.Write("done.");
             Console.WriteLine();
@@ -364,15 +384,14 @@ namespace AzureDatabaseDownloader
         }
 
         /// <summary>
-        /// Runs a PII anonymization script against the freshly imported LOCAL database, then
-        /// shreds the intermediate .bacpac so no unmasked production data lingers on disk.
-        /// No-op when no script is supplied. Never touches the source/Azure database.
+        /// Runs a PII anonymization script against the freshly imported LOCAL database.
+        /// No-op (returns false) when no script is supplied. Never touches the source database.
         /// </summary>
-        private static void ApplyMaskingScript(string outputConnectionString, string db, string quotedDatabaseName, string? maskingScript, string? bacpacToDelete)
+        private static bool ApplyMaskingScript(string outputConnectionString, string db, string quotedDatabaseName, string? maskingScript)
         {
             if (string.IsNullOrWhiteSpace(maskingScript))
             {
-                return;
+                return false;
             }
 
             if (!File.Exists(maskingScript))
@@ -400,14 +419,44 @@ namespace AzureDatabaseDownloader
             }
 
             Console.WriteLine($"[{db}] Masking complete");
+            return true;
+        }
 
-            // The masked DB is now the source of truth for dev. The raw export still contains
-            // unmasked production data, so delete it.
-            if (!string.IsNullOrEmpty(bacpacToDelete) && File.Exists(bacpacToDelete))
+        /// <summary>
+        /// EXECs the configured stored procedures against the freshly imported LOCAL database,
+        /// after any masking. Each entry is run as "EXEC &lt;entry&gt;" so it may include arguments
+        /// (e.g. "dbo.MyCleanup @Confirm = 1"). Returns false when none are supplied. Never
+        /// touches the source database.
+        /// </summary>
+        private static bool ApplyPostImportProcedures(string outputConnectionString, string db, string quotedDatabaseName, string[]? procedures)
+        {
+            if (procedures == null || procedures.Length == 0)
             {
-                File.Delete(bacpacToDelete);
-                Console.WriteLine($"[{db}] Deleted unmasked export {Path.GetFileName(bacpacToDelete)}");
+                return false;
             }
+
+            using var conn = new SqlConnection(outputConnectionString);
+            conn.Open();
+
+            foreach (var proc in procedures)
+            {
+                if (string.IsNullOrWhiteSpace(proc))
+                {
+                    continue;
+                }
+
+                Console.WriteLine($"[{db}] Running post-import procedure: EXEC {proc}");
+
+                using var cmd = new SqlCommand($"USE {quotedDatabaseName};\nEXEC {proc};", conn)
+                {
+                    CommandTimeout = 0 // a purge/cleanup proc can touch large tables; no timeout
+                };
+
+                cmd.ExecuteNonQuery();
+            }
+
+            Console.WriteLine($"[{db}] Post-import procedures complete");
+            return true;
         }
 
         /// <summary>

--- a/ProjectProfile.cs
+++ b/ProjectProfile.cs
@@ -21,6 +21,13 @@ namespace AzureDatabaseDownloader
         /// </summary>
         public Dictionary<string, string>? MaskingScripts { get; set; }
 
+        /// <summary>
+        /// Optional stored procedures to EXEC against the local target after import (and after
+        /// any masking script), applied to every database this profile syncs. Each entry runs
+        /// as EXEC &lt;entry&gt;, so it may include arguments, e.g. [ "dbo.MyCleanup @Confirm = 1" ].
+        /// </summary>
+        public string[]? PostImportProcedures { get; set; }
+
         public static IEnumerable<ProjectProfile> List()
         {
             if (!File.Exists(ProfilePath))

--- a/masking/README.md
+++ b/masking/README.md
@@ -19,11 +19,33 @@ mechanism to run one during a sync.
   "maskingScripts": { "MyDb": "path/to/anonymize-MyDb.sql" }
   ```
 
-When a masking script runs on a `db2db` sync, the intermediate `.bacpac` (which still holds
-raw production data) is **deleted** afterwards, so only the masked database remains on disk.
+When a masking script (or a post-import procedure, below) runs on a `db2db` sync, the
+intermediate `.bacpac` (which still holds raw production data) is **deleted** afterwards, so
+only the sanitized database remains on disk.
 
 > `db2f` (export-to-file) intentionally produces a **raw** bacpac and is not masked — it's a
 > straight export. To get a masked file, `db2db` into a scratch DB, then export that.
+
+## Post-import procedures
+
+Instead of (or in addition to) a script file, you can have the tool `EXEC` stored procedures
+that already live in the database — handy when the cleanup logic ships with your schema, so
+there is no external file/path to distribute. They run **after** any masking script.
+
+- **CLI:** `-p/--post-import-procedures` (`;`-separated).
+  ```
+  AzureDatabaseDownloader db2db -i "<source>" -o "server=localhost;..." -d MyDb -p "dbo.MyCleanup @Confirm = 1"
+  ```
+- **Interactive/profiles:** a `postImportProcedures` list on the profile, applied to every
+  database that profile syncs.
+  ```json
+  "postImportProcedures": [ "dbo.MyCleanup @Confirm = 1" ]
+  ```
+
+Each entry is run as `EXEC <entry>`, so it may include arguments. As with masking, this only
+ever writes to the local target — never the source. (Masking scripts stay keyed per database,
+since different databases in a profile may need different anonymization; procedures are a
+project-level operation.)
 
 ## Recommended script design
 

--- a/profiles.sample.json
+++ b/profiles.sample.json
@@ -10,6 +10,7 @@
 		"excludeTables": [ "dbo.Tables", "dbo.To", "dbo.Exclude", "(must include schema)" ],
 		"maskingScripts": {
 			"SampleDatabase1": "path/to/anonymize-SampleDatabase1.sql"
-		}
+		},
+		"postImportProcedures": [ "dbo.MyCleanupProc @Confirm = 1" ]
 	}
 ]


### PR DESCRIPTION
## Why

Sometimes the post-import cleanup/sanitization logic is better kept as stored procedures that ship with the schema (always version-matched, no external script file to distribute). This adds a hook to call them after import, complementing the existing `--masking-script` file hook.

## What

- New `-p/--post-import-procedures` option (`;`-separated) on `db2db`/`f2db`, plus a **project-level** `postImportProcedures` list on a profile.
- The profile list applies to **every database that profile syncs** — procedures are a per-project operation, so (unlike `maskingScripts`, which stays keyed per database) they aren't keyed by database name.
- Each entry is run as `EXEC <entry>` against the **local target**, so it may include arguments (e.g. `dbo.MyCleanup @Confirm = 1`). They run **after** any masking script.
- The source database is only ever read — procedures only run on the local copy.
- The intermediate `.bacpac` is now deleted when **either** a masking script **or** a post-import procedure runs (previously only on masking), so a procedure-only sanitize still shreds the raw export.

```json
"postImportProcedures": [ "dbo.MyCleanup @Confirm = 1" ]
```

See `masking/README.md` for usage.

## Verification

- Builds clean (0 warnings / 0 errors).
